### PR TITLE
Update wp_bootstrap_navwalker.php

### DIFF
--- a/devdmbootstrap3/lib/wp_bootstrap_navwalker.php
+++ b/devdmbootstrap3/lib/wp_bootstrap_navwalker.php
@@ -110,7 +110,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
              * property is NOT null we apply it as the class name for the glyphicon.
              */
             if ( ! empty( $item->attr_title ) )
-                $item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
+                $item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>';
             else
                 $item_output .= '<a'. $attributes .'>';
 


### PR DESCRIPTION
Removed &amp;nbsp; after glyphicon.   If your menu item has a class attribute it will set attr_title and will add empty glyph icon container and prefix menus with a space.
